### PR TITLE
rescheduling geneva satRday

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,19 +88,19 @@ These are satRdays organiser groups / locations that have already run a satRday 
 ### Rest of World [0/3 slots filled]
 
 ## New satRdays in October - December 2019
-### Europe [1/3 slots filled]
-- Geneva, CH
-    + Owner: [@sinarueeger](//github.com/sinarueeger) and [@xvrdm](//github.com/xvrdm)
-    + Expected size: ...
-    + Date: 2019 Q4
-    + Additional info: ...
-    
+### Europe [0/3 slots filled]
 ### US [0/3 slots filled]
 ### Rest of World [0/3 slots filled]
 
 
 ## New satRdays in January - March 2020
-### Europe [0/3 slots filled]
+### Europe [1/3 slots filled]
+- Geneva, CH
+    + Owner: [@sinarueeger](//github.com/sinarueeger) and [@xvrdm](//github.com/xvrdm)
+    + Expected size: ~80
+    + Date: 2020 Q1
+    + Additional info: ...
+    
 ### US [0/3 slots filled]
 ### Rest of World [1/3 slots filled]
 


### PR DESCRIPTION
Hi
@xvrdm and I need to reschedule the Geneva event due to conflicting schedules. 
Moving from Q4-2019 to Q1-2020. 

