### PR TITLE
Remove Santiago de Compostela's event

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ These are satRdays organiser groups / locations that have already run a satRday 
     
 ## New satRdays in July - September 2020
 
-### Europe [2/3 slots filled]
+### Europe [3/3 slots filled]
 
 - Limerick, IE
     + Owner: [@dragonflystats](www.twitter.com/dragonfystats)

--- a/README.md
+++ b/README.md
@@ -130,12 +130,6 @@ These are satRdays organiser groups / locations that have already run a satRday 
     + Expected size: 200
     + Date: September 26, 2020
     + Additional info: https://bratislava2020.satrdays.org
-
-- Santiago de Compostela, ES
-    + Owner: [@bea](//github.com/chucheria)
-    + Expected size: 150
-    + Date: September 12th, 2020
-    + Additional info: 
     
 
 ### US [0/3 slots filled]

--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ These are satRdays organiser groups / locations that have already run a satRday 
     + Expected size: 200
     + Date: September 26, 2020
     + Additional info: https://bratislava2020.satrdays.org
+
+- Santiago de Compostela, ES
+    + Owner: [@bea](//github.com/chucheria)
+    + Expected size: 150
+    + Date: September 12th, 2020
+    + Additional info: 
     
 
 ### US [0/3 slots filled]


### PR DESCRIPTION
Due to COVID-19 we decided to postpone Santiago de Compostela's event to the second trimester of 2021 